### PR TITLE
Evaluate prim_type in current environment; add some tests

### DIFF
--- a/R/prim_type.R
+++ b/R/prim_type.R
@@ -14,7 +14,7 @@
 #' prim_type(formals(mean))
 #' prim_type(formals(mean)[[1]])
 prim_type <- function(x) {
-  prim_type_(quote(x), environment)
+  prim_type_(quote(x), environment())
 }
 
 #' @export

--- a/tests/testthat/test-desc.R
+++ b/tests/testthat/test-desc.R
@@ -1,0 +1,5 @@
+context("prim_desc")
+
+test_that("basic type descriptions are correct", {
+  expect_equal(prim_desc(c(1,2,3)), "[3]")
+})

--- a/tests/testthat/test-type.R
+++ b/tests/testthat/test-type.R
@@ -1,0 +1,12 @@
+context("prim_type")
+
+test_that("basic types are correct", {
+  expect_equal(prim_type("a"), "character")
+  expect_equal(prim_type(1), "double")
+  expect_equal(prim_type(1L), "integer")
+  expect_equal(prim_type(function() { 1; }), "function")
+})
+
+test_that("S3 types are reported", {
+  expect_equal(prim_type(data.frame(a = 1)), "list (S3: data.frame)")
+})


### PR DESCRIPTION
This fixes a problem wherein `prim_type` reports an error when invoked (`Error: cannot convert to environment`), and adds a few tests.